### PR TITLE
Windows Container fixes

### DIFF
--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -1,6 +1,6 @@
 param(
     [string]$tag,
-    [string]$registryRootRepos = "/server",
+    [string]$registryRootRepos = "server",
     [string]$baseBinariesPath = ".",
     [switch]$setLatestTag = $false
 )
@@ -14,6 +14,11 @@ $ErrorActionPreference = "Stop"
 write-host "Building inrule-server base image."
 set-location "$PSScriptRoot\inrule-server" 
 docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:$tag .
+
+if ($setLatestTag -eq $true ) {
+    write-host "Setting image $version to latest..."
+    docker image tag ${registryRootRepos}/inrule-server:$tag ${registryRootRepos}/inrule-server:latest
+}
 
 Write-Host "Building inrule-catalog image."
 set-location "$PSScriptRoot\inrule-catalog"
@@ -32,8 +37,6 @@ if ($setLatestTag -eq $true ) {
     docker image tag ${registryRootRepos}/inrule-catalog:$tag ${registryRootRepos}/inrule-catalog:latest
 
     docker image tag ${registryRootRepos}/inrule-runtime:$tag ${registryRootRepos}/inrule-runtime:latest
-
-    docker image tag ${registryRootRepos}/inrule-server:$tag ${registryRootRepos}/inrule-server:latest
 
     docker image tag ${registryRootRepos}/inrule-catalog-manager:$tag ${registryRootRepos}/inrule-catalog-manager:latest
 }

--- a/Developer Samples/WindowsContainers/inrule-catalog-manager/Start.ps1
+++ b/Developer Samples/WindowsContainers/inrule-catalog-manager/Start.ps1
@@ -1,6 +1,7 @@
+write-host "Container IP address: $(get-netipaddress)"
 $last = Get-Date
 while ($true) {
-    start-sleep -seconds 2;
-    Get-WinEvent -FilterHashtable @{ StartTime = $last; } -ErrorAction SilentlyContinue | format-list
+    start-sleep -seconds 5;
+    (Get-WinEvent -FilterHashtable @{ StartTime = $last; ProviderName = "InRule*" } -ErrorAction SilentlyContinue) | format-list
     $last = Get-Date
 }

--- a/Developer Samples/WindowsContainers/inrule-server/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-server/DOCKERFILE
@@ -11,7 +11,7 @@ SHELL ["powershell", "-Command"]
 ADD . c:\temp\
 WORKDIR c:\temp\
 RUN .\InRuleServerDSC.ps1 -Wait;
-COPY [".\\InRuleLicense.xml", "C:\\Program Data\\InRule\\Shared Licenses"]
+COPY [".\\InRuleLicense.xml", "C:\\ProgramData\\InRule\\SharedLicenses\\InRuleLicense.xml"]
 RUN New-EventLog -LogName InRule -Source "InRule.Repository","InRule.Repository.Service","InRule.Runtime","InRule.Runtime.Service","InRule.Authoring.irAuthor","InRule.Admin.CatalogManager"
 
 # REMARK: Temporary workaround for Windows DNS client weirdness


### PR DESCRIPTION
Hi,

A couple of small fixes to the Windows Container samples:
- correct the license file location (runs in grace period mode otherwise)
- fix error logged during catalog manager startup
- move tagging of base server image as 'latest' before build of dependent images