### PR TITLE
Remove container license from docker image

### DIFF
--- a/Developer Samples/WindowsContainers/inrule-catalog/readme.md
+++ b/Developer Samples/WindowsContainers/inrule-catalog/readme.md
@@ -4,13 +4,13 @@
 
 * The irCatalog service is a WCF service hosted by IIS. The DOCKERFILE will copy the assets into the image, and expects a flat folder structure.
 * Prior to building the image, copy the irServer RepositoryService IisService assets (default is usually `C:\Program Files (x86)\InRule\irServer\RepositoryService\IisService\`) into the repository's irCatalog directory (/irCatalog/)
-* See [inrule-server](/inrule-server/) documentation for information on licensing
+* See [inrule-server](../inrule-server/) documentation for information on licensing
 
 ### List of required environment properties
 
 * CatalogUser - the SQL login that the service will use to connect to the DB
 * CatalogPassword - the SQL password that the service will use to connect to the DB. **Not encrypted, viewable in logs**
-* CatalogDbHost - defaults to `db` (assumes `--link db` passed to `docker run`). May require manually setting if host name resolution fails
+* CatalogDbHost - defaults to `db`
 
 Note that the catalog database must already be present with schema before the catalog service will be fully operational.
 
@@ -32,10 +32,12 @@ The `-v` option tells Docker to mount the contents of the given host directory -
 
 You can build this image from source using a command similar to the following example:
 
-`docker build -t server/inrule-catalog:5.0.14 .`
+`docker build -t server/inrule-catalog:5.0.26 .`
 
 ## Running the image
 
-`docker run -d --name cat -e CatalogUserName=sa -e CatalogPassword=<SA_PASSWORD> --link db server/inrule-catalog:latest`
+Place the `InRuleLicense.xml` file in a location where the IIS process inside the docker container will be able to read it (e.g. not under a user's home directory)
 
-When running this image, you'll need to supply all required and any optional environment parameters. Use of a link to a container running the InRuleCatalog DB is recommended, but not required.
+`docker run -d --name cat -e CatalogUser=sa -e CatalogPassword=<SA_PASSWORD> -e CatalogDbHost=<DB_HOST> -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' server/inrule-catalog:latest`
+
+When running this image, you'll need to supply all required and any optional environment parameters.

--- a/Developer Samples/WindowsContainers/inrule-runtime/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-runtime/DOCKERFILE
@@ -10,7 +10,9 @@ LABEL	maintainer="jelster@inrule.com" `
 ARG irRuntimeDir
 ARG ContainerDir
 
-ENV CatalogUri="http://cat/InRuleCatalogService/Service.svc" `    
+ENV CatalogUri="http://cat/InRuleCatalogService/Service.svc" `
+CatalogUser="" `
+CatalogPass="" `
 ContainerDir=${ContainerDir:-"C:\inrule-runtime"}
 
 ADD ${irRuntimeDir:-irServer} ${ContainerDir}
@@ -26,6 +28,6 @@ EXPOSE 443:443
 COPY *.ps1 c:\temp\
 WORKDIR C:\temp
 
-ENTRYPOINT .\Set-RuntimeConfig.ps1 -catalogServiceUri $env:CatalogUri -installPath $env:ContainerDir -Verbose;
+ENTRYPOINT .\Set-RuntimeConfig.ps1 -catalogServiceUri $env:CatalogUri -catalogUser $env:CatalogUser -catalogPass $env:CatalogPass -installPath $env:ContainerDir -Verbose;
 
 CMD .\Start.ps1

--- a/Developer Samples/WindowsContainers/inrule-runtime/Set-RuntimeConfig.ps1
+++ b/Developer Samples/WindowsContainers/inrule-runtime/Set-RuntimeConfig.ps1
@@ -30,8 +30,8 @@ if ($null -eq $catSvc) {
 }
 
 $catSvc.SetAttribute("catalogServiceUri", $catalogServiceUri)
-$catSvc.SetAttribute("userName", "")
-$catSvc.SetAttribute("password", "")
+$catSvc.SetAttribute("userName", $catalogUser)
+$catSvc.SetAttribute("password", $catalogPass)
 
 if ($endpointAssemblyPath -ne $null -and $endpointAssemblyPath -ne "") {
     write-verbose "Setting endpointAssemblyPath to $endpointAssemblyPath in config"

--- a/Developer Samples/WindowsContainers/inrule-runtime/readme.md
+++ b/Developer Samples/WindowsContainers/inrule-runtime/readme.md
@@ -4,7 +4,7 @@
 
 * You must have a valid license for irCatalog.
 * Prior to building the image, copy the irServer RuleEngineService IisService assets (default is usually `C:\Program Files (x86)\InRule\irServer\RuleEngineService\IisService`) into this repository's `/irServer/` directory.
-* See [inrule-server](/inrule-server/) documentation for information on licensing
+* See [inrule-server](../inrule-server/) documentation for information on licensing
 
 ## About this image
 
@@ -18,7 +18,7 @@
 
 #### Using defaults
 
-```docker build -t server/inrule-runtime:5.0.14 .```
+```docker build -t server/inrule-runtime:5.0.26 .```
 
 #### Specifying an alternative path for source artifacts
 
@@ -31,11 +31,13 @@ Once the container starts it will be listening on the designated ports (80 by de
 SOAP: `http://<container name or ip>/Service.svc`
 REST: `http://<container name or ip>/HttpService.svc`
 
+Place the `InRuleLicense.xml` file in a location where the IIS process inside the docker container will be able to read it (e.g. not under a user's home directory)
+
 ### Basic usage connecting to external catalog
 
 ```cmd
 
-docker run -d -p 80:80 --env CatalogUri='https://contoso-catalog.cloudapp.net/Service.svc' server/inrule-runtime:latest
+docker run -d -p 80:80 --env CatalogUri='https://contoso-catalog.cloudapp.net/Service.svc' -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' server/inrule-runtime:latest
 
 ```
 
@@ -43,7 +45,7 @@ docker run -d -p 80:80 --env CatalogUri='https://contoso-catalog.cloudapp.net/Se
 
 ```cmd
 
-docker run -d --link cat --env CatalogUri='https://cat/Service.svc' server/inrule-runtime:latest
+docker run -d --link cat --env CatalogUri='https://cat/Service.svc' -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' server/inrule-runtime:latest
 
 ```
 
@@ -51,7 +53,15 @@ Using a volume mount for file-based ruleapps and a container link to a container
 
 ```cmd
 
-docker run -d --rm --name=rex -v c:\inrule-ruleapps\:c:\RuleApps\ -P --link=cat server/inrule-runtime:latest
+docker run -d --rm --name=rex -v c:\inrule-ruleapps\:c:\RuleApps\ -P --link=cat -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' server/inrule-runtime:latest
+
+```
+
+Using a volume mount for endpoint assemblies and a container link to a container running irCatalog:
+
+```cmd
+
+docker run -d --rm --name=rex -v c:\inrule-assemblies\:c:\inrule-runtime\bin\EndpointAssemblies\ -P --link=cat -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' server/inrule-runtime:latest
 
 ```
 

--- a/Developer Samples/WindowsContainers/inrule-server/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-server/DOCKERFILE
@@ -11,7 +11,6 @@ SHELL ["powershell", "-Command"]
 ADD . c:\temp\
 WORKDIR c:\temp\
 RUN .\InRuleServerDSC.ps1 -Wait;
-COPY [".\\InRuleLicense.xml", "C:\\ProgramData\\InRule\\SharedLicenses\\InRuleLicense.xml"]
 RUN New-EventLog -LogName InRule -Source "InRule.Repository","InRule.Repository.Service","InRule.Runtime","InRule.Runtime.Service","InRule.Authoring.irAuthor","InRule.Admin.CatalogManager"
 
 # REMARK: Temporary workaround for Windows DNS client weirdness

--- a/Developer Samples/WindowsContainers/inrule-server/readme.md
+++ b/Developer Samples/WindowsContainers/inrule-server/readme.md
@@ -5,8 +5,6 @@
 You must have a valid license for InRule to use these images. By using these images you agree to the InRule EULA.
 Contact support@inrule.com to check for and obtain the appropriate license file.
 
-**Important!** Place the InRuleLicense.xml file you received from InRule Support into the same directory as the DOCKERFILE.
-
 ## Environment
 
 Windows Server Core Base OS image
@@ -15,13 +13,9 @@ Windows Server Core Base OS image
 
 This image serves as a base image for other inrule server-based components. It ensures that the necessary pre-requisites have been fulfilled (e.g., IIS is installed, WCF is configured, etc) and that InRule event log sources are created.
 
-When the image is built, it will copy the InRule license file to the container's `"C:\Program Data\InRule\Shared Licenses` folder.
-
 ## Usage
 
 ### Docker build
-
-#### Make sure your license file is in the same directory as the dockerfile prior to building the image
 
 ```docker build -t inrule-server .```
 


### PR DESCRIPTION
Hi,

These are the changes that I ended up applying to build my local docker images.

- Removes the baked in license file (inject into container via volume mount instead)
- Allows configuration of the CatalogUser and CatalogPassword for the runtime image
- Updates the documentation (as a side note, could probably get rid of the `--link` stuff for referencing other containers as that's deprecated now. As long as they're on the same docker network, they should be able to be resolved by container name. https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/)