### PR TITLE
Add official docker hub images

### DIFF
--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -1,7 +1,6 @@
 param(
     [string]$tag,
     [string]$registryRootRepos = "inrule",
-    [string]$baseBinariesPath = ".",
     [switch]$setLatestTag = $false,
     [switch]$skipServerBuild = $false
 )

--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -1,8 +1,8 @@
 param(
     [string]$tag,
-    [string]$registryRootRepos = "/server",
-    [string]$baseBinariesPath = ".",
-    [switch]$setLatestTag = $false
+    [string]$registryRootRepos = "server",
+    [switch]$setLatestTag = $false,
+    [string]$defaultInRuleInstallFolder = "C:\Program Files (x86)\InRule\"
 )
 Push-Location $PSScriptRoot
 
@@ -13,17 +13,23 @@ if ($tag -ne "latest") {
 $ErrorActionPreference = "Stop"
 write-host "Building inrule-server base image."
 set-location "$PSScriptRoot\inrule-server" 
-docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:$tag .
+docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:latest .
 
-Write-Host "Building inrule-catalog image."
+$hostCatalogPath = resolve-path "$defaultInRuleInstallFolder\irServer\RepositoryService\IisService\"
+Write-Host "Building inrule-catalog image using assets at $hostCatalogPath"
+Copy-Item $hostCatalogPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog\irCatalog\" -Verbose
 set-location "$PSScriptRoot\inrule-catalog"
 docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog:$tag .
 
+$hostRuntimePath = resolve-path $defaultInRuleInstallFolder\irServer\RuleEngineService\IisService
 write-host "Building inrule-runtime image."
+Copy-Item -Path $hostRuntimePath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-runtime\irServer" -Verbose
 set-location "$PSScriptRoot\inrule-runtime"
 docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-runtime:$tag .
 
+$hostCatManPath = resolve-path $defaultInRuleInstallFolder\irServer\CatalogManagerWeb
 write-host "Building inrule-catalog-manager image."
+Copy-Item -Path $hostCatManPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog-manager\CatalogManagerWeb" -Verbose
 set-location "$PSScriptRoot\inrule-catalog-manager"
 docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog-manager:$tag .
 

--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -1,6 +1,6 @@
 param(
     [string]$tag,
-    [string]$registryRootRepos = "server",
+    [string]$registryRootRepos = "inrule",
     [string]$baseBinariesPath = ".",
     [switch]$setLatestTag = $false
 )

--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -2,7 +2,8 @@ param(
     [string]$tag,
     [string]$registryRootRepos = "inrule",
     [string]$baseBinariesPath = ".",
-    [switch]$setLatestTag = $false
+    [switch]$setLatestTag = $false,
+    [switch]$skipServerBuild = $false
 )
 Push-Location $PSScriptRoot
 
@@ -11,13 +12,15 @@ if ($tag -ne "latest") {
     $version = $tag
 }
 $ErrorActionPreference = "Stop"
-write-host "Building inrule-server base image."
-set-location "$PSScriptRoot\inrule-server" 
-docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:$tag .
 
-if ($setLatestTag -eq $true ) {
-    write-host "Setting image $version to latest..."
-    docker image tag ${registryRootRepos}/inrule-server:$tag ${registryRootRepos}/inrule-server:latest
+if ($skipServerBuild -eq $false) {
+    write-host "Building inrule-server base image."
+    set-location "$PSScriptRoot\inrule-server" 
+    docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:$tag .
+    if ($setLatestTag -eq $true ) {
+        write-host "Setting image $version to latest..."
+        docker image tag ${registryRootRepos}/inrule-server:$tag ${registryRootRepos}/inrule-server:latest
+    }
 }
 
 Write-Host "Building inrule-catalog image."

--- a/Developer Samples/WindowsContainers/inrule-catalog-manager/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-catalog-manager/DOCKERFILE
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM server/inrule-server:latest
+FROM inrule/inrule-server:latest
 
 LABEL	maintainer="jelster@inrule.com" `
 		vendor="InRule Technology, Inc." `

--- a/Developer Samples/WindowsContainers/inrule-catalog/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-catalog/DOCKERFILE
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM server/inrule-server:latest
+FROM inrule/inrule-server:latest
 
 LABEL	maintainer="jelster@inrule.com" `
 		vendor="InRule Technology, Inc." `

--- a/Developer Samples/WindowsContainers/inrule-catalog/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-catalog/DOCKERFILE
@@ -24,9 +24,6 @@ RUN $acl = Get-Acl -AllCentralAccessPolicies -Path c:\inetpub\wwwroot;(gci $env:
 RUN Import-Module "WebAdministration";`
     set-itemproperty -path 'IIS:\Sites\Default Web Site\' -Name physicalPath -Value $env:ContainerDir
 
-#RUN Import-Module "WebAdministration";`
-#    new-item 'IIS:\Sites\Default Web Site\InRuleCatalogService' -physicalPath C:\InRule\ -type Application -Verbose;
-
 EXPOSE 80:80
 EXPOSE 443:443
 EXPOSE 1433:1433

--- a/Developer Samples/WindowsContainers/inrule-runtime/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-runtime/DOCKERFILE
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM server/inrule-server:latest
+FROM inrule/inrule-server:latest
 
 LABEL	maintainer="jelster@inrule.com" `
 		vendor="InRule Technology, Inc." `

--- a/Developer Samples/WindowsContainers/inrule-server/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-server/DOCKERFILE
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM microsoft/windowsservercore:latest
+FROM microsoft/dotnet-framework:4.7.1-windowsservercore-1709
 
 LABEL	maintainer="jelster@inrule.com" `
 		vendor="InRule Technology, Inc." `
@@ -12,6 +12,3 @@ ADD . c:\temp\
 WORKDIR c:\temp\
 RUN .\InRuleServerDSC.ps1 -Wait;
 RUN New-EventLog -LogName InRule -Source "InRule.Repository","InRule.Repository.Service","InRule.Runtime","InRule.Runtime.Service","InRule.Authoring.irAuthor","InRule.Admin.CatalogManager"
-
-# REMARK: Temporary workaround for Windows DNS client weirdness
-#RUN powershell set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord

--- a/Developer Samples/WindowsContainers/inrule-server/readme.md
+++ b/Developer Samples/WindowsContainers/inrule-server/readme.md
@@ -1,7 +1,3 @@
-# InRule Samples
-
-## Sample Title
-
 # README for the inrule-server DOCKER image
 
 ## Notes regarding licensing

--- a/Developer Samples/WindowsContainers/readme.md
+++ b/Developer Samples/WindowsContainers/readme.md
@@ -1,8 +1,6 @@
 # InRule Samples
 
-## Sample Title
-
-# InRule Docker images
+## InRule Docker images
 
 ## Image descriptions
 
@@ -14,11 +12,11 @@
 
 * Catalog management is provided by [inrule-catalog-manager](inrule-catalog-manager/). RuleApplications can be viewed, labeled, and promoted. Users can be created and modified along with permissions.
 
-* Catalog database persistence is provided by SQL Server Express and comes from [microsoft/mssql-server-windows-express](https://github.com/Microsoft/sql-server-samples/tree/master/samples/manage/windows-containers/mssql-server-2016-express-sp1-windows)
+* Although most flavors of SQL are supported (SQL Server, MySQL, Oracle, etc.) irCatalog database persistence is provided by SQL Server Express and comes from [microsoft/mssql-server-windows-express](https://github.com/Microsoft/sql-server-samples/tree/master/samples/manage/windows-containers/mssql-server-2016-express-sp1-windows)
 
 ### Image repository and registry
 
-Images can be built using the respective dockerfiles in this repository. Because the images produced embed the InRule License key into them, you should refrain from making images publically available.
+Images can be built using the respective dockerfiles in this repository. Take care to protect your license key file by avoiding pushing images containing a license key file to public repositories
 
 ### Building the images
 

--- a/Developer Samples/WindowsContainers/readme.md
+++ b/Developer Samples/WindowsContainers/readme.md
@@ -20,7 +20,13 @@ Images can be built using the respective dockerfiles in this repository. Take ca
 
 ### Building the images
 
-To build all of the sample images using the included build script, first clone the repository into a working directory. Next, run the [build.ps1](/build.ps1) script in an elevated Powershell prompt, passing in the name of the tag you'd like to use:
+Here are the steps to building these images from their base assets. To build the sample images using the included build script:
+
+1. Clone the repository into a working directory
+
+2. Copy into the repository's respective directories the contents of the related irServer directory. Always copy the *lowest* directory level. For example, for the `inrule-catalog` image, copy the assets installed by default to `%Program Files (x86)%\InRule\irServer\RepositoryService\IisService\` into the `\inrule-catalog\irCatalog` folder. Repeat the process for the other two service components (inrule-runtime and inrule-catalog-manager).
+
+3. Run the [build.ps1](/build.ps1) script in an elevated Powershell prompt at the root of this repository, passing in the name of the tag you'd like to use:
 
 `.\build.ps1 -tag '5.0.24'`
 
@@ -28,10 +34,12 @@ If you want to also have the images tagged as 'latest', pass `-SetLatestTag` to 
 
 `.\build.ps1 -tag '5.0.24' -setLatestTag`
 
-Unless otherwise specified, InRule assets (e.g., irCatalog, irServer components) will be copied into their respective directories by the build script. The default installation location of `C:\Program Files (x86)\InRule\irServer` is used for this, but can be overridden by providing a value for the `defaultInRuleInstallFolder` parameter:
+To skip building the `inrule-server` base image, pass the `skipServerBuild` switch to the build script.
+
+<!-- Unless otherwise specified, InRule assets (e.g., irCatalog, irServer components) will be copied into their respective directories by the build script. The default installation location of `C:\Program Files (x86)\InRule\irServer` is used for this, but can be overridden by providing a value for the `defaultInRuleInstallFolder` parameter:
 
 `.\build.ps1 -tag '5.0.26 -defaultInRuleInstallFolder 'z:\inrule\'`
-
+-->
 <!-- For instructions on building a set of images using Compose, see the section below on **Using Docker Compose to provision a rule execution environment** -->
 Please see the instructions for each respective image for information on how to build the individual images.
 

--- a/Developer Samples/WindowsContainers/readme.md
+++ b/Developer Samples/WindowsContainers/readme.md
@@ -26,6 +26,10 @@ If you want to also have the images tagged as 'latest', pass `-SetLatestTag` to 
 
 `.\build.ps1 -tag '5.0.24' -setLatestTag`
 
+Unless otherwise specified, InRule assets (e.g., irCatalog, irServer components) will be copied into their respective directories by the build script. The default installation location of `C:\Program Files (x86)\InRule\irServer` is used for this, but can be overridden by providing a value for the `defaultInRuleInstallFolder` parameter:
+
+`.\build.ps1 -tag '5.0.26 -defaultInRuleInstallFolder 'z:\inrule\'`
+
 <!-- For instructions on building a set of images using Compose, see the section below on **Using Docker Compose to provision a rule execution environment** -->
 Please see the instructions for each respective image for information on how to build the individual images.
 


### PR DESCRIPTION
Resolves #14 . 

- Stabilize windows OS version in base server image to `dotnet-framework:4.7.1-windowsservercore-1709` instead of simply `latest`

- Fix copy issues in README

- Update copy in README's

- Add switch to conditionally build base server image when running build script