### PR TITLE
Build improvements

### DIFF
--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -11,10 +11,15 @@ if ($tag -ne "latest") {
     $version = $tag
 }
 $ErrorActionPreference = "Stop"
-write-host "Building inrule-server base image."
-set-location "$PSScriptRoot\inrule-server" 
-docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:latest .
-
+if ($skipServerBuild -eq $false) { 
+    write-host "Building inrule-server base image."
+    set-location "$PSScriptRoot\inrule-server" 
+    docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:$tag .
+    if ($setLatestTag -eq $true ) {
+        write-host "Setting image $version to latest..."
+        docker image tag ${registryRootRepos}/inrule-server:$tag ${registryRootRepos}/inrule-server:latest    
+    } 
+}
 $hostCatalogPath = resolve-path "$defaultInRuleInstallFolder\irServer\RepositoryService\IisService\"
 Write-Host "Building inrule-catalog image using assets at $hostCatalogPath"
 Copy-Item $hostCatalogPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog\irCatalog\" -Verbose

--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -3,6 +3,7 @@ param(
     [string]$tag,
     [string]$registryRootRepos = "inrule",
     [switch]$setLatestTag = $false,
+    [switch]$skipServerBuild = $false,
     [string]$defaultInRuleInstallFolder = "C:\Program Files (x86)\InRule\"
 )
 Push-Location $PSScriptRoot

--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -1,6 +1,6 @@
 param(
     [string]$tag,
-    [string]$registryRootRepos = "server",
+    [string]$registryRootRepos = "inrule",
     [switch]$setLatestTag = $false,
     [string]$defaultInRuleInstallFolder = "C:\Program Files (x86)\InRule\"
 )

--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -32,23 +32,29 @@ if ($skipServerBuild -eq $false) {
 }
 
 $hostCatalogPath = resolve-path "$defaultInRuleInstallFolder\irServer\RepositoryService\IisService\"
-set-location "$PSScriptRoot\inrule-catalog"
+$catalogBuildPath = "$PSScriptRoot\inrule-catalog"
+set-location $catalogBuildPath
 if ($PSCmdlet.ShouldProcess("Building inrule-catalog image using assets at $hostCatalogPath")) {
-    Copy-Item $hostCatalogPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog\irCatalog\"
+    Remove-Item -Path $catalogBuildPath\irCatalog\ -Include *.* -Recurse -Force
+    Copy-Item $hostCatalogPath\** -Recurse -Force -Destination "$catalogBuildPath\irCatalog\" 
     docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog:$tag .
 }
 
 $hostRuntimePath = resolve-path $defaultInRuleInstallFolder\irServer\RuleEngineService\IisService
-set-location "$PSScriptRoot\inrule-runtime"
+$runtimeBuildPath = "$PSScriptRoot\inrule-runtime"
+set-location $runtimeBuildPath
 if ($PSCmdlet.ShouldProcess("Building inrule-runtime image using assets at $hostRuntimePath")) {
-    Copy-Item -Path $hostRuntimePath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-runtime\irServer"
+    Remove-Item -Path $runtimeBuildPath\irServer\ -Include *.* -Recurse -Force
+    Copy-Item -Path $hostRuntimePath\** -Recurse -Force -Destination "$runtimeBuildPath\irServer"
     docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-runtime:$tag .
 }
 
 $hostCatManPath = resolve-path $defaultInRuleInstallFolder\irServer\CatalogManagerWeb
-set-location "$PSScriptRoot\inrule-catalog-manager"
+$catmanBuildPath = "$PSScriptRoot\inrule-catalog-manager"
+set-location $catmanBuildPath
 if ($PSCmdlet.ShouldProcess("Building inrule-catalog-manager image using assets at $hostCatManPath")) {
-    Copy-Item -Path $hostCatManPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog-manager\CatalogManagerWeb"
+    Remove-Item -Path $catmanBuildPath\CatalogManagerWeb -Include *.* -Recurse -Force
+    Copy-Item -Path $hostCatManPath\** -Recurse -Force -Destination "$catmanBuildPath\CatalogManagerWeb"
     docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog-manager:$tag .
 }
 

--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -1,3 +1,4 @@
+[CmdletBinding(SupportsShouldProcess=$true)]
 param(
     [string]$tag,
     [string]$registryRootRepos = "inrule",
@@ -11,36 +12,46 @@ Write-Host "Attempting to determine the version number for assets located at $de
 $version = (Get-ChildItem $defaultInRuleInstallFolder\*\InRule.Common.dll -recurse)[0].VersionInfo.ProductVersion
 Write-Host "Using InRule version $version"
 
+if (([String]::IsNullOrWhiteSpace($tag) -and ($null -ne $version))) {
+    Write-Host "No value supplied for image tag. Using $version for tagging images."
+    $tag = $version
+}
+Write-Host "Images will be tagged $tag. Also tag them as latest? $setLatestTag"
+
 $ErrorActionPreference = "Stop"
 if ($skipServerBuild -eq $false) { 
     write-host "Building inrule-server base image."
     set-location "$PSScriptRoot\inrule-server" 
-    docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:$tag .
-    if ($setLatestTag -eq $true ) {
-        write-host "Setting image $version to latest..."
+    if ($PSCmdlet.ShouldProcess("Building inrule-server base image")) {
+        docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:$tag . 
+    }
+    if ($setLatestTag -eq $true -and $PSCmdlet.ShouldProcess("Setting image $version to latest...")) {
         docker image tag ${registryRootRepos}/inrule-server:$tag ${registryRootRepos}/inrule-server:latest    
-    } 
+    }
 }
+
 $hostCatalogPath = resolve-path "$defaultInRuleInstallFolder\irServer\RepositoryService\IisService\"
-Write-Host "Building inrule-catalog image using assets at $hostCatalogPath"
-Copy-Item $hostCatalogPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog\irCatalog\" -Verbose
 set-location "$PSScriptRoot\inrule-catalog"
-docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog:$tag .
+if ($PSCmdlet.ShouldProcess("Building inrule-catalog image using assets at $hostCatalogPath")) {
+    Copy-Item $hostCatalogPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog\irCatalog\"
+    docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog:$tag .
+}
 
 $hostRuntimePath = resolve-path $defaultInRuleInstallFolder\irServer\RuleEngineService\IisService
-write-host "Building inrule-runtime image."
-Copy-Item -Path $hostRuntimePath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-runtime\irServer" -Verbose
 set-location "$PSScriptRoot\inrule-runtime"
-docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-runtime:$tag .
+if ($PSCmdlet.ShouldProcess("Building inrule-runtime image using assets at $hostRuntimePath")) {
+    Copy-Item -Path $hostRuntimePath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-runtime\irServer"
+    docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-runtime:$tag .
+}
 
 $hostCatManPath = resolve-path $defaultInRuleInstallFolder\irServer\CatalogManagerWeb
-write-host "Building inrule-catalog-manager image."
-Copy-Item -Path $hostCatManPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog-manager\CatalogManagerWeb" -Verbose
 set-location "$PSScriptRoot\inrule-catalog-manager"
-docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog-manager:$tag .
+if ($PSCmdlet.ShouldProcess("Building inrule-catalog-manager image using assets at $hostCatManPath")) {
+    Copy-Item -Path $hostCatManPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog-manager\CatalogManagerWeb"
+    docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog-manager:$tag .
+}
 
-if ($setLatestTag -eq $true ) {
-    write-host "Setting image $tag to latest..."
+if ($setLatestTag -eq $true -and $PSCmdlet.ShouldProcess("Setting image $tag to latest...") ) {
     docker image tag ${registryRootRepos}/inrule-catalog:$tag ${registryRootRepos}/inrule-catalog:latest
 
     docker image tag ${registryRootRepos}/inrule-runtime:$tag ${registryRootRepos}/inrule-runtime:latest

--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -1,8 +1,8 @@
 param(
     [string]$tag,
-    [string]$registryRootRepos = "/server",
-    [string]$baseBinariesPath = ".",
-    [switch]$setLatestTag = $false
+    [string]$registryRootRepos = "server",
+    [switch]$setLatestTag = $false,
+    [string]$defaultInRuleInstallFolder = "C:\Program Files (x86)\InRule\"
 )
 Push-Location $PSScriptRoot
 
@@ -13,17 +13,23 @@ if ($tag -ne "latest") {
 $ErrorActionPreference = "Stop"
 write-host "Building inrule-server base image."
 set-location "$PSScriptRoot\inrule-server" 
-docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:$tag .
+docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-server:latest .
 
-Write-Host "Building inrule-catalog image."
+$hostCatalogPath = resolve-path "$defaultInRuleInstallFolder\irServer\RepositoryService\IisService\"
+Write-Host "Building inrule-catalog image using assets at $hostCatalogPath"
+Copy-Item $hostCatalogPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog\irCatalog\" -Verbose
 set-location "$PSScriptRoot\inrule-catalog"
 docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog:$tag .
 
+$hostRuntimePath = resolve-path $defaultInRuleInstallFolder\irServer\RuleEngineService\IisService
 write-host "Building inrule-runtime image."
+Copy-Item -Path $hostRuntimePath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-runtime\irServer" -Verbose
 set-location "$PSScriptRoot\inrule-runtime"
 docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-runtime:$tag .
 
+$hostCatManPath = resolve-path $defaultInRuleInstallFolder\irServer\CatalogManagerWeb
 write-host "Building inrule-catalog-manager image."
+Copy-Item -Path $hostCatManPath\** -Recurse -Force -Destination "$PSScriptRoot\inrule-catalog-manager\CatalogManagerWeb" -Verbose
 set-location "$PSScriptRoot\inrule-catalog-manager"
 docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog-manager:$tag .
 

--- a/Developer Samples/WindowsContainers/build.ps1
+++ b/Developer Samples/WindowsContainers/build.ps1
@@ -7,9 +7,10 @@ param(
 Push-Location $PSScriptRoot
 
 $version = $null
-if ($tag -ne "latest") {    
-    $version = $tag
-}
+Write-Host "Attempting to determine the version number for assets located at $defaultInRuleInstallFolder"
+$version = (Get-ChildItem $defaultInRuleInstallFolder\*\InRule.Common.dll -recurse)[0].VersionInfo.ProductVersion
+Write-Host "Using InRule version $version"
+
 $ErrorActionPreference = "Stop"
 if ($skipServerBuild -eq $false) { 
     write-host "Building inrule-server base image."
@@ -39,7 +40,7 @@ set-location "$PSScriptRoot\inrule-catalog-manager"
 docker build --label "com.inrule.version=$version" -t ${registryRootRepos}/inrule-catalog-manager:$tag .
 
 if ($setLatestTag -eq $true ) {
-    write-host "Setting image $version to latest..."
+    write-host "Setting image $tag to latest..."
     docker image tag ${registryRootRepos}/inrule-catalog:$tag ${registryRootRepos}/inrule-catalog:latest
 
     docker image tag ${registryRootRepos}/inrule-runtime:$tag ${registryRootRepos}/inrule-runtime:latest

--- a/Developer Samples/WindowsContainers/inrule-catalog-manager/README.md
+++ b/Developer Samples/WindowsContainers/inrule-catalog-manager/README.md
@@ -23,7 +23,7 @@ Typically, there's no need to modify this value in your builds.
 
 ```cmd
 
-docker build -t server/inrule-catalog-manager:5.0.14 .
+docker build -t inrule/inrule-catalog-manager:5.0.14 .
 
 ```
 
@@ -31,7 +31,7 @@ docker build -t server/inrule-catalog-manager:5.0.14 .
 
 ```cmd
 
-docker build --build-arg catManDir=c:\users\jsmith\downloads\irServer -t server/inrule-catalog-manager:5.0.12 .
+docker build --build-arg catManDir=c:\users\jsmith\downloads\irServer -t inrule/inrule-catalog-manager:5.0.12 .
 
 ```
 
@@ -43,7 +43,7 @@ Once started, you can open a web browser and navigate to the IP address of the c
 
 ```cmd
 
-docker run server/inrule-catalog-manager:latest
+docker run inrule/inrule-catalog-manager:latest
 
 ```
 

--- a/Developer Samples/WindowsContainers/inrule-catalog-manager/README.md
+++ b/Developer Samples/WindowsContainers/inrule-catalog-manager/README.md
@@ -1,8 +1,6 @@
 # InRule Samples
 
-## Sample Title
-
-# README for Web Catalog Manager DOCKERFILE
+## README for Web Catalog Manager DOCKERFILE
 
 ## Important notes on building the image
 
@@ -55,6 +53,6 @@ This will start a container running the Web Catalog Manager site using the defau
 
 ```cmd
 
-docker run -d --env CatalogUri=https://acme-catalog.cloudapp.net/Service.svc server/inrule-catalog-manager:latest
+docker run -d --env CatalogUri=https://acme-catalog.cloudapp.net/Service.svc inrule/inrule-catalog-manager:latest
 
 ```

--- a/Developer Samples/WindowsContainers/inrule-catalog/readme.md
+++ b/Developer Samples/WindowsContainers/inrule-catalog/readme.md
@@ -1,8 +1,6 @@
 # InRule Samples
 
-## Windows Containers
-
-This README describes the irCatalog Docker file.
+## README for the irCatalog Docker file
 
 ### Important notes on building the image
 
@@ -36,12 +34,12 @@ The `-v` option tells Docker to mount the contents of the given host directory -
 
 You can build this image from source using a command similar to the following example:
 
-`docker build -t server/inrule-catalog:5.0.26 .`
+`docker build -t inrule/inrule-catalog:5.0.26 .`
 
 ### Running the image
 
 Place the `InRuleLicense.xml` file in a location where the IIS process inside the docker container will be able to read it (e.g. not under a user's home directory)
 
-`docker run -d --name cat -e CatalogUser=sa -e CatalogPassword=<SA_PASSWORD> -e CatalogDbHost=<DB_HOST> -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' server/inrule-catalog:latest`
+`docker run -d --name cat -e CatalogUser=sa -e CatalogPassword=<SA_PASSWORD> -e CatalogDbHost=<DB_HOST> -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' inrule/inrule-catalog:latest`
 
 When running this image, you'll need to supply all required and any optional environment parameters.

--- a/Developer Samples/WindowsContainers/inrule-runtime/readme.md
+++ b/Developer Samples/WindowsContainers/inrule-runtime/readme.md
@@ -1,8 +1,6 @@
 # InRule Samples
 
-## Sample Title
-
-# README for the inrule-runtime DOCKER image
+## README for the inrule-runtime DOCKER image
 
 ## Important notes on building the image
 
@@ -22,11 +20,11 @@
 
 #### Using defaults
 
-```docker build -t server/inrule-runtime:5.0.26 .```
+```docker build -t inrule/inrule-runtime:5.0.26 .```
 
 #### Specifying an alternative path for source artifacts
 
-```docker build --build-arg irRuntimeDir=c:\users\jsmith\downloads\irServer -t server/inrule-runtime:5.0.12 .```
+```docker build --build-arg irRuntimeDir=c:\users\jsmith\downloads\irServer -t inrule/inrule-runtime:5.0.12 .```
 
 ## Running the image
 
@@ -41,7 +39,7 @@ Place the `InRuleLicense.xml` file in a location where the IIS process inside th
 
 ```cmd
 
-docker run -d -p 80:80 --env CatalogUri='https://contoso-catalog.cloudapp.net/Service.svc' -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' server/inrule-runtime:latest
+docker run -d -p 80:80 --env CatalogUri='https://contoso-catalog.cloudapp.net/Service.svc' -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' inrule/inrule-runtime:latest
 
 ```
 
@@ -49,7 +47,7 @@ docker run -d -p 80:80 --env CatalogUri='https://contoso-catalog.cloudapp.net/Se
 
 ```cmd
 
-docker run -d --link cat --env CatalogUri='https://cat/Service.svc' -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' server/inrule-runtime:latest
+docker run -d --link cat --env CatalogUri='https://cat/Service.svc' -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' inrule/inrule-runtime:latest
 
 ```
 
@@ -57,7 +55,7 @@ Using a volume mount for file-based ruleapps and a container link to a container
 
 ```cmd
 
-docker run -d --rm --name=rex -v c:\inrule-ruleapps\:c:\RuleApps\ -P --link=cat -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' server/inrule-runtime:latest
+docker run -d --rm --name=rex -v c:\inrule-ruleapps\:c:\RuleApps\ -P --link=cat -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' inrule/inrule-runtime:latest
 
 ```
 
@@ -65,7 +63,7 @@ Using a volume mount for endpoint assemblies and a container link to a container
 
 ```cmd
 
-docker run -d --rm --name=rex -v c:\inrule-assemblies\:c:\inrule-runtime\bin\EndpointAssemblies\ -P --link=cat -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' server/inrule-runtime:latest
+docker run -d --rm --name=rex -v c:\inrule-assemblies\:c:\inrule-runtime\bin\EndpointAssemblies\ -P --link=cat -v '<HOST_LICENSE_DIRECTORY>:C:\ProgramData\InRule\SharedLicenses:ro' inrule/inrule-runtime:latest
 
 ```
 

--- a/Developer Samples/WindowsContainers/readme.md
+++ b/Developer Samples/WindowsContainers/readme.md
@@ -26,6 +26,10 @@ If you want to also have the images tagged as 'latest', pass `-SetLatestTag` to 
 
 `.\build.ps1 -tag '5.0.24' -setLatestTag`
 
+Unless otherwise specified, InRule assets (e.g., irCatalog, irServer components) will be copied into their respective directories by the build script. The default installation location of `C:\Program Files (x86)\InRule\irServer` is used for this, but can be overridden by providing a value for the `defaultInRuleInstallFolder` parameter:
+
+`.\build.ps1 -tag '5.0.26 -defaultInRuleInstallFolder 'z:\inrule\'`
+
 <!-- For instructions on building a set of images using Compose, see the section below on **Using Docker Compose to provision a rule execution environment** -->
 Please see the instructions for each respective image for information on how to build the individual images.
 


### PR DESCRIPTION
This PR will improve and streamline the build process for images so that it is easier and more reliable to build and push the official images.

A new parameter to the build script allows users to supply a path to where inrule assets are stored. The default value points at the default installation location for the InRule irServer components. 

The build script also now supports `-WhatIf` via the ShouldProcess functionality for easier testing. 