### PR TITLE
Fix runtime configuration values not being set

### DIFF
--- a/Developer Samples/WindowsContainers/docker-compose.override.yml
+++ b/Developer Samples/WindowsContainers/docker-compose.override.yml
@@ -1,0 +1,11 @@
+version: '2.4'
+
+services: 
+    rex:
+      volumes:
+        - 'c:\ProgramData\InRule\SharedLicenses:c:\ProgramData\InRule\SharedLicenses:ro'
+    cat:
+      volumes:
+        - 'c:\ProgramData\InRule\SharedLicenses:c:\ProgramData\InRule\SharedLicenses:ro'         
+    webcatman:
+         

--- a/Developer Samples/WindowsContainers/docker-compose.yml
+++ b/Developer Samples/WindowsContainers/docker-compose.yml
@@ -17,6 +17,8 @@ services:
         depends_on:
             - cat
         image: inrule/inrule-catalog-manager:v5.1.1
+        ports:
+            - "80"
     db:
         image: inrule/inrule-catalog-db:v5.1.1
         ports:

--- a/Developer Samples/WindowsContainers/inrule-catalog-manager/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-catalog-manager/DOCKERFILE
@@ -6,7 +6,7 @@ WORKDIR C:\assets\
 ADD https://github.com/InRule/AzureAppServices/releases/download/${reposTag}/InRule.Catalog.Manager.Web.zip c:\assets
 
 RUN Expand-Archive -Path InRule.Catalog.Manager.Web.zip -Destination c:\assets
-
+RUN Remove-Item .\InRule.Catalog.Manager.Web.zip
 FROM inrule/inrule-server:latest as deploy
 
 EXPOSE 80:80
@@ -27,8 +27,9 @@ COPY *.ps1 .\
 
 RUN $acl = Get-Acl -AllCentralAccessPolicies -Path c:\inetpub\wwwroot;(gci ${catManDir} -Recurse) | foreach { Set-Acl -Path $_.FullName -AclObject $acl -ErrorAction SilentlyContinue }
 
-RUN Import-Module "WebAdministration";set-itemproperty -path 'IIS:\Sites\Default Web Site\' -Name physicalPath -Value $env:catManDir
+RUN Import-Module "WebAdministration";set-itemproperty -path 'IIS:\Sites\Default Web Site' -Name physicalPath -Value $env:catManDir
 
 # HACK to disable TLS in WCF bindings until SSL is supported
 RUN (Get-Content $env:catManDir\web.config) | foreach { $_.Replace('Transport', 'None') } | set-content "$env:catManDir\web.config" -force
+ENTRYPOINT .\Set-CatalogManagerConfig.ps1 -verbose;
 CMD .\Start.ps1

--- a/Developer Samples/WindowsContainers/inrule-catalog-manager/Set-CatalogManagerConfig.ps1
+++ b/Developer Samples/WindowsContainers/inrule-catalog-manager/Set-CatalogManagerConfig.ps1
@@ -1,0 +1,44 @@
+[OutputType("System.Int32")]
+[CmdletBinding(SupportsShouldProcess = $true)]    
+param(
+    [string]$catalogUri = $env:InRule:Catalog:Uri,
+    [string]$installPath = "$env:catManDir"    
+)
+function Set-CatalogManagerConfig {    
+    function New-AppSettingsEntry {
+        param([XML]$parentDoc, [string]$key, [string]$value)
+    
+        $appSetting = $parentDoc.CreateElement("add")
+        $appSetting.SetAttribute("key", $key)
+        $appSetting.SetAttribute("value", $value)
+        return $appSetting
+    }
+
+    write-output "Replacing supplied configuration values in web.config..."
+    $configFilePath = resolve-Path -Path (Join-Path -Path $installPath -ChildPath "Web.config")
+
+    if ((test-path $installPath) -eq $false) {
+        throw "cannot find path to service configuration file.";
+        return -1;
+    }
+
+    $cfgXml = new-object Xml
+    $cfgXml.Load($configFilePath)
+    $catSvc = $cfgXml.configuration["appSettings"]
+    if ($null -eq $catSvc) {
+         
+        $catSvc = $cfgXml.CreateElement("appSettings")        
+        $cfgXml.configuration.appendChild($catSvc)
+        write-verbose "Added appSettings node to 'inrule.repository.service'"
+    }
+
+    $cs = New-AppSettingsEntry -parentDoc $cfgXml -key "InRule.Catalog.Uri" -value $catalogUri
+    
+    $catSvc.AppendChild($cs)    
+    $cfgXml.Save($configFilePath)
+
+
+    write-output "Saved configuration changes."
+    return 0;   
+}
+Set-CatalogManagerConfig $PSBoundParameters

--- a/Developer Samples/WindowsContainers/inrule-catalog/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-catalog/DOCKERFILE
@@ -6,6 +6,7 @@ ARG reposTag=v5.1.1
 WORKDIR C:\assets\
 ADD https://github.com/InRule/AzureAppServices/releases/download/${reposTag}/InRule.Catalog.Service.zip c:\assets
 RUN Expand-Archive -Path InRule.Catalog.Service.zip -Destination c:\assets
+RUN Remove-Item .\InRule.Catalog.Service.zip, .\InRuleLicense.xml
 
 FROM inrule/inrule-server:latest as deploy
 EXPOSE 80:80
@@ -27,8 +28,11 @@ COPY *.ps1 .\
 
 RUN $acl = Get-Acl -AllCentralAccessPolicies -Path c:\inetpub\wwwroot;(gci $env:ContainerDir -Recurse) | foreach { Set-Acl -Path $_.FullName -AclObject $acl -ErrorAction SilentlyContinue }
 
-RUN Import-Module "WebAdministration";set-itemproperty -path 'IIS:\Sites\Default Web Site\' -Name physicalPath -Value $env:ContainerDir
+RUN Import-Module "WebAdministration";set-itemproperty -path 'IIS:\Sites\Default Web Site' -Name physicalPath -Value $env:ContainerDir
 
 # HACK to disable TLS in WCF bindings until SSL is supported
 RUN (Get-Content C:\inrule-catalog\web.config) | foreach { $_.Replace('Transport', 'None') } | set-content "c:\inrule-catalog\web.config" -force
-CMD .\Start.ps1;
+ 
+# HACK to add new appSettings configuration until environment variable support is added
+ENTRYPOINT .\Set-CatalogConfig.ps1 -verbose;
+CMD .\Start.ps1

--- a/Developer Samples/WindowsContainers/inrule-catalog/Set-CatalogConfig.ps1
+++ b/Developer Samples/WindowsContainers/inrule-catalog/Set-CatalogConfig.ps1
@@ -1,0 +1,44 @@
+[OutputType("System.Int32")]
+[CmdletBinding(SupportsShouldProcess = $true)]    
+param(
+    [string]$connectionString = $env:inrule:repository:service:connectionString,
+    [string]$installPath = "$env:ContainerDir"    
+)
+function Set-CatalogConfig {    
+    function New-AppSettingsEntry {
+        param([XML]$parentDoc, [string]$key, [string]$value)
+    
+        $appSetting = $parentDoc.CreateElement("add")
+        $appSetting.SetAttribute("key", $key)
+        $appSetting.SetAttribute("value", $value)
+        return $appSetting
+    }
+
+    write-output "Replacing supplied configuration values in web.config..."
+    $configFilePath = resolve-Path -Path (Join-Path -Path $installPath -ChildPath "Web.config")
+
+    if ((test-path $installPath) -eq $false) {
+        throw "cannot find path to service configuration file.";
+        return -1;
+    }
+
+    $cfgXml = new-object Xml
+    $cfgXml.Load($configFilePath)
+    $catSvc = $cfgXml.configuration["appSettings"]
+    if ($null -eq $catSvc) {
+         
+        $catSvc = $cfgXml.CreateElement("appSettings")        
+        $cfgXml.configuration.appendChild($catSvc)
+        write-verbose "Added appSettings node to 'inrule.repository.service'"
+    }
+
+    $cs = New-AppSettingsEntry -parentDoc $cfgXml -key "inrule:repository:service:connectionString" -value $connectionString
+    
+    $catSvc.AppendChild($cs)    
+    $cfgXml.Save($configFilePath)
+
+
+    write-output "Saved configuration changes."
+    return 0;   
+}
+Set-CatalogConfig $PSBoundParameters

--- a/Developer Samples/WindowsContainers/inrule-runtime/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-runtime/DOCKERFILE
@@ -6,9 +6,9 @@ ARG reposTag=v5.1.1
 WORKDIR C:\assets\
 ADD https://github.com/InRule/AzureAppServices/releases/download/${reposTag}/InRule.Runtime.Service.zip c:\assets
 RUN Expand-Archive -Path InRule.Runtime.Service.zip -Destination c:\assets
+RUN Remove-Item .\InRule.Runtime.Service.zip, .\InRuleLicense.xml
 
 FROM inrule/inrule-server:latest as deploy
-
 
 LABEL	maintainer="jelster@inrule.com" `
 		vendor="InRule Technology, Inc." `
@@ -19,7 +19,7 @@ LABEL	maintainer="jelster@inrule.com" `
 EXPOSE 80:80
 EXPOSE 443:443
 
-ENV inrule:runtime:service:catalog:catalogServiceUri="http://cat/InRuleCatalogService/Service.svc" `
+ENV inrule:runtime:service:catalog:catalogServiceUri="http://cat/Service.svc" `
 inrule:runtime:service:catalog:userName="" `
 inrule:runtime:service:catalog:password="" `
 ContainerDir="C:\inrule-runtime"
@@ -30,8 +30,12 @@ COPY *.ps1 .\
 
 RUN $acl = Get-Acl -AllCentralAccessPolicies -Path c:\inetpub\wwwroot;(gci $env:ContainerDir -Recurse) | foreach { Set-Acl -Path $_.FullName -AclObject $acl -ErrorAction SilentlyContinue }
 
-RUN Import-Module "WebAdministration";`
-    set-itemproperty -path 'IIS:\Sites\Default Web Site\' -Name physicalPath -Value $env:ContainerDir
+RUN Import-Module "WebAdministration";set-itemproperty -path 'IIS:\Sites\Default Web Site' -Name physicalPath -Value $env:ContainerDir
+
 # HACK to disable TLS in WCF bindings until SSL is supported
+
 RUN (Get-Content $env:ContainerDir\web.config) | foreach { $_.Replace('Transport', 'None') } | set-content "$env:ContainerDir\web.config" -force
+
+# HACK to add new appSettings configuration until environment variable support is added
+ENTRYPOINT .\Set-RuntimeConfig.ps1 -verbose;
 CMD .\Start.ps1

--- a/Developer Samples/WindowsContainers/inrule-runtime/Set-RuntimeConfig.ps1
+++ b/Developer Samples/WindowsContainers/inrule-runtime/Set-RuntimeConfig.ps1
@@ -1,0 +1,53 @@
+[OutputType("System.Int32")]
+[CmdletBinding(SupportsShouldProcess = $true)]    
+param(
+    [string]$catalogUser = "",
+    [string]$catalogPass = "",
+    [string]$installPath = "$env:ContainerDir",
+    [string]$restRuleApplication = "C:\RuleApps",
+    [string]$catalogServiceUri = "${env:inrule:runtime:service:catalog:catalogServiceUri}",
+    [string]$endpointAssemblyPath = "EndpointAssemblies"
+)
+function Set-RuntimeConfig {    
+    function New-AppSettingsEntry {
+        param([XML]$parentDoc, [string]$key, [string]$value)
+    
+        $appSetting = $parentDoc.CreateElement("add")
+        $appSetting.SetAttribute("key", $key)
+        $appSetting.SetAttribute("value", $value)
+        return $appSetting
+    }
+
+    write-output "Replacing supplied configuration values in web.config..."
+    $configFilePath = resolve-Path -Path (Join-Path -Path $installPath -ChildPath "Web.config")
+
+    if ((test-path $installPath) -eq $false) {
+        throw "cannot find path to service configuration file.";
+        return -1;
+    }
+
+    $cfgXml = new-object Xml
+    $cfgXml.Load($configFilePath)
+    $catSvc = $cfgXml.configuration["appSettings"]
+    if ($null -eq $catSvc) {
+         
+        $catSvc = $cfgXml.CreateElement("appSettings")        
+        $cfgXml.configuration.appendChild($catSvc)
+        write-verbose "Added appSettings node to 'inrule.repository.service'"
+    }
+
+    $cUri = New-AppSettingsEntry -parentDoc $cfgXml -key 'inrule:runtime:service:catalog:catalogServiceUri' -value $catalogServiceUri
+    $cUser = New-AppSettingsEntry -parentDoc $cfgXml -key 'inrule:runtime:service:catalog:userName' -value $catalogUser
+    $cPass = New-AppSettingsEntry -parentDoc $cfgXml -key 'inrule:runtime:service:catalog:password' -value $catalogPass
+    
+    $catSvc.AppendChild($cUri)
+    $catSvc.AppendChild($cUser)
+    $catSvc.AppendChild($cPass)
+    
+    $cfgXml.Save($configFilePath)
+
+
+    write-output "Saved configuration changes."
+    return 0;   
+}
+Set-RuntimeConfig $PSBoundParameters


### PR DESCRIPTION
The last PR modified the container images under the incorrect assumption that environment variables were getting read with the rest of the config settings. This fixes those assumptions

also, adds docker-compose support for a full up and down rule execution experience