### PR TITLE
Update base image to windows server 1803 (was 1709)

### DIFF
--- a/Developer Samples/WindowsContainers/docker-compose.yml
+++ b/Developer Samples/WindowsContainers/docker-compose.yml
@@ -2,24 +2,31 @@ version: '2.4'
 
 services: 
     rex:
+        isolation: process
         depends_on:
             - cat
         image: inrule/inrule-runtime:v5.1.1
         ports:
             - "80"
     cat:
+        isolation: process
         depends_on:
             - db
         image: inrule/inrule-catalog:v5.1.1
         ports:
             - "80"
     webcatman:
+        isolation: process
         depends_on:
             - cat
         image: inrule/inrule-catalog-manager:v5.1.1
         ports:
             - "80"
     db:
+        isolation: process
         image: inrule/inrule-catalog-db:v5.1.1
         ports:
             - "1433"
+
+    
+   

--- a/Developer Samples/WindowsContainers/inrule-server/DOCKERFILE
+++ b/Developer Samples/WindowsContainers/inrule-server/DOCKERFILE
@@ -1,6 +1,6 @@
 # escape=`
 
-FROM microsoft/dotnet-framework:4.7.1-windowsservercore-1709
+FROM microsoft/aspnet:4.7.2-20180911-windowsservercore-1803
 
 LABEL	maintainer="jelster@inrule.com" `
 		vendor="InRule Technology, Inc." `


### PR DESCRIPTION
I promise this is the last PR from this branch! :) 

This PR updates the base inrule-server's DOCKERFILE to pull from the microsoft/aspnet repos. At the same time, I took advantage of the need to change the base image repos to update the OS from 1709 to 1803. Among other fixes and improvements (many around networking), the change has made the overall image size drop considerably, saving around 2GB for the uncompressed image (1GB compressed savings). In addition, this PR sets the isolation mode for docker-compose to "process" (default is hyper-v). 

Here's a table of the various images showing the drop in image size from earlier versions:

```
REPOSITORY                      TAG                 IMAGE ID            CREATED             SIZE
inrule/inrule-catalog-manager   v5.1.1              70d4e321fcb4        45 minutes ago      5.74GB
inrule/inrule-runtime           v5.1.1              fbc788b6feeb        About an hour ago   5.72GB
inrule/inrule-catalog           v5.1.1              c3b41941f004        About an hour ago   5.73GB
inrule/inrule-server            latest              ccbdd96601e8        About an hour ago   5.6GB
inrule/inrule-runtime           v5.1.1b             ad942d2fba7b        27 hours ago        7.92GB
inrule/inrule-catalog-manager   <none>              e45a587923f1        7 days ago          7.95GB
inrule/inrule-runtime           <none>              bf3673b330a5        7 days ago          7.93GB
inrule/inrule-catalog           <none>              b1204d5fd6bd        7 days ago          7.94GB
inrule/inrule-catalog-db        v5.1.1              b2951d506323        3 weeks ago         13.9GB
inrule/inrule-runtime           5.1.0.150c          33366e27f1a1        2 months ago        7.86GB
inrule/inrule-catalog-manager   5.1.0.150           821ceaabdc27        2 months ago        7.9GB
inrule/inrule-catalog           5.1.0.150           8d94d05047ab        2 months ago        7.87GB
inrule/inrule-catalog-manager   5.0.29.136          a7e9ad558932        6 months ago        7.7GB
inrule/inrule-runtime           5.0.29.136          53ee20acc837        6 months ago        7.66GB
inrule/inrule-catalog           5.0.29.136          8dda78e4f95f        6 months ago        7.66GB
inrule/inrule-catalog           5.0.28.135          716b31000f1b        6 months ago        7.66GB
inrule/inrule-catalog-manager   5.0.28.135          e454c1b3f9c1        6 months ago        7.69GB
inrule/inrule-runtime           5.0.28.135          f80cfc2cbf89        6 months ago        7.66GB
inrule/inrule-catalog-manager   5.0.27              40763c925813        8 months ago        11GB
inrule/inrule-runtime           5.0.27              0920a67eaff3        8 months ago        10.9GB
inrule/inrule-catalog           5.0.27              67b0635338af        8 months ago        10.9GB


```

