### PR TITLE
SEAL-2916: update copyright to 2021

### DIFF
--- a/Developer Samples/AddCollectionMembers/Properties/AssemblyInfo.cs
+++ b/Developer Samples/AddCollectionMembers/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("AddCollectionMembers")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/CheckinRequestListener/Properties/AssemblyInfo.cs
+++ b/Developer Samples/CheckinRequestListener/Properties/AssemblyInfo.cs
@@ -8,10 +8,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("CheckinRequestListener")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("CheckinRequestListener")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
-[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
+[assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/Developer Samples/CommandLineTools/ExecuteTests/Properties/AssemblyInfo.cs
+++ b/Developer Samples/CommandLineTools/ExecuteTests/Properties/AssemblyInfo.cs
@@ -8,10 +8,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("ExecuteTests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("ExecuteTests")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
-[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
+[assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/Developer Samples/CreateEntityFromXml/Properties/AssemblyInfo.cs
+++ b/Developer Samples/CreateEntityFromXml/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("CreateEntityFromXml")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/CreateRuleSession-Catalog/Properties/AssemblyInfo.cs
+++ b/Developer Samples/CreateRuleSession-Catalog/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("CreateRuleSession-Catalog")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/CreateRuleSession-FileSystem/Properties/AssemblyInfo.cs
+++ b/Developer Samples/CreateRuleSession-FileSystem/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/CreateRuleSession-InMemory/Properties/AssemblyInfo.cs
+++ b/Developer Samples/CreateRuleSession-InMemory/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("CreateRuleSession-InMemory")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/DynamicValueAccess/Properties/AssemblyInfo.cs
+++ b/Developer Samples/DynamicValueAccess/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("DynamicValueAccess")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/EmbedAuthoringControl/Properties/AssemblyInfo.cs
+++ b/Developer Samples/EmbedAuthoringControl/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("EmbedAuthoringControl")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/EmbeddedWinFormInRule/Properties/AssemblyInfo.cs
+++ b/Developer Samples/EmbeddedWinFormInRule/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("WindowsFormsApplication1")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/GetChangedValues/Properties/AssemblyInfo.cs
+++ b/Developer Samples/GetChangedValues/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("GetChangedValues")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/GetEntityXml/Properties/AssemblyInfo.cs
+++ b/Developer Samples/GetEntityXml/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("GetEntityXml")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/LaunchIrVerify/Properties/AssemblyInfo.cs
+++ b/Developer Samples/LaunchIrVerify/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("LaunchIrVerify")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/LibraryLogEnabler/LibLogEnabler/Properties/AssemblyInfo.cs
+++ b/Developer Samples/LibraryLogEnabler/LibLogEnabler/Properties/AssemblyInfo.cs
@@ -8,10 +8,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LibLogEnabler")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("LibLogEnabler")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
-[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
+[assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/Developer Samples/LibraryLogger/LoggerApp/Properties/AssemblyInfo.cs
+++ b/Developer Samples/LibraryLogger/LoggerApp/Properties/AssemblyInfo.cs
@@ -8,10 +8,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("LoggerApp")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("LoggerApp")]
-[assembly: AssemblyCopyright("Copyright © 2020")]
-[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
+[assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/Developer Samples/RESTImplementation/Properties/AssemblyInfo.cs
+++ b/Developer Samples/RESTImplementation/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("RESTImplementation")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/RuleApplicationCache/Properties/AssemblyInfo.cs
+++ b/Developer Samples/RuleApplicationCache/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("RuleApplicationCache")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/RuleServices45/InRule.RuleServices.ASPMVCTestUI/Properties/AssemblyInfo.cs
+++ b/Developer Samples/RuleServices45/InRule.RuleServices.ASPMVCTestUI/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("InRule.RuleServices.ASPMVCTestUI")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/RuleServices45/InRule.RuleServices.Common/Properties/AssemblyInfo.cs
+++ b/Developer Samples/RuleServices45/InRule.RuleServices.Common/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("InRule.RuleServices.Common")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/RuleServices45/InRule.RuleServices.HtmlTestUI/Properties/AssemblyInfo.cs
+++ b/Developer Samples/RuleServices45/InRule.RuleServices.HtmlTestUI/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("InRule.RuleServices.HtmlTestUI")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/RuleServices45/InRule.RuleServices/Properties/AssemblyInfo.cs
+++ b/Developer Samples/RuleServices45/InRule.RuleServices/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("InRule.RuleServices")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/RulesInCode/Properties/AssemblyInfo.cs
+++ b/Developer Samples/RulesInCode/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("RulesInCode")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/SalesForceSamples/SalesForceUtility/Properties/AssemblyInfo.cs
+++ b/Developer Samples/SalesForceSamples/SalesForceUtility/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("SalesForceUtility")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/SalesForceSamples/WCFTestClient/Properties/AssemblyInfo.cs
+++ b/Developer Samples/SalesForceSamples/WCFTestClient/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("WCFTestClient")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/UseDictionaryAsState/Properties/AssemblyInfo.cs
+++ b/Developer Samples/UseDictionaryAsState/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("UseDictionaryAsState")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/UseExpandoObjectAsState/Properties/AssemblyInfo.cs
+++ b/Developer Samples/UseExpandoObjectAsState/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("UseExpandoObjectAsState")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/WebServiceCall/Properties/AssemblyInfo.cs
+++ b/Developer Samples/WebServiceCall/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("WebServiceCall")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/WorkflowConsoleApplication/Model/Properties/AssemblyInfo.cs
+++ b/Developer Samples/WorkflowConsoleApplication/Model/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("Model")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/WorkflowConsoleApplication/Properties/AssemblyInfo.cs
+++ b/Developer Samples/WorkflowConsoleApplication/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("WorkflowConsoleApplication")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 

--- a/Developer Samples/Wpf.ObjectAsStateInvoice/InvoiceObjects/AssemblyInfo.cs
+++ b/Developer Samples/Wpf.ObjectAsStateInvoice/InvoiceObjects/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("InvoiceObjects")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]		
 

--- a/Developer Samples/Wpf.ObjectAsStateInvoice/Wpf.ObjectAsStateInvoice/Properties/AssemblyInfo.cs
+++ b/Developer Samples/Wpf.ObjectAsStateInvoice/Wpf.ObjectAsStateInvoice/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("InRule Technology, Inc.")]
 [assembly: AssemblyProduct("Wpf.ObjectAsStateInvoice")]
-[assembly: AssemblyCopyright("Copyright © 2020, InRule Technology, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2021, InRule Technology, Inc.")]
 [assembly: AssemblyTrademark("InRule® is a registered trademark of InRule Technology.  All Rights Reserved.")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
Update all InRule Samples with the most current copyright date and ensure all assemblies have expected Assembly info.